### PR TITLE
font options menu

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,7 +85,7 @@
       {/if}
       {#if is_font_menu_open}
       <menu
-          class={`${theme.value === "light" ? "border-black" : "border-[#00091d]"} w-fit border z-50 flex flex-col items-center gap-2 h-fit p-2 rounded-xl bg-white ml-[50px]`}
+          class={`${theme.value === "light" ? "border-black" : "border-[#00091d]"} w-fit border z-50 flex flex-col items-center gap-2 h-fit p-2 rounded-xl bg-white ml-[75px]`}
         >
           <button
             onclick={() => { font_size.value = "small"; } }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,14 +8,38 @@
   import { persisted, pinned_list } from "$lib/stores.svelte";
 
   let theme = persisted<string>("theme", "dark");
+  let font_size = persisted("font_size", "large");
+
   let is_menu_open = $state(false);
+  let is_font_menu_open = $state(false);
+
   let theme_style = $derived(theme.value === "dark"
     ? "text-white absolute top-0 z-[-2] h-screen w-screen bg-[#000000] bg-[radial-gradient(#ffffff33_1px,#00091d_1px)] bg-[size:20px_20px]"
     : "text-black absolute inset-0 -z-10 h-full w-full bg-white bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px]"
   );
+  let font_style = $derived(font_size.value === "small"
+    ? "text-xs"
+    : font_size.value === "medium"
+    ? "text-base"
+    : "text-lg"
+  );
 
   function comingSoon() {
     toast("Coming soon!", { icon: "🙈", position: "top-center" });
+  }
+
+  function toggleMenus(menu: 'main' | 'font') {
+    if (menu === 'main') {
+      is_menu_open = !is_menu_open;
+      if (is_menu_open) {
+        is_font_menu_open = false;
+      }
+    } else if (menu === 'font') {
+      is_font_menu_open = !is_font_menu_open;
+      if (is_font_menu_open) {
+        is_menu_open = false;
+      }
+    }
   }
 
   onMount(() => {
@@ -23,9 +47,10 @@
       goto(`/${pinned_list.value}`);
     }
   });
+
 </script>
 
-<div class={`${theme_style} font-apfel flex flex-col w-full h-full min-w-screen min-h-screen p-8 overflow-auto`}>
+<div class={`${theme_style} font-apfel ${font_style} flex flex-col w-full h-full min-w-screen min-h-screen p-8 overflow-auto`}>
   <section class="p-4 w-full h-full">
     <slot />
   </section>
@@ -34,7 +59,6 @@
     <div class="flex flex-col justify-start gap-4 pointer-events-auto">
       {#if is_menu_open}
         <menu 
-          transition:fade={{ duration: 150 }}
           class={`${theme.value === "light" ? "border-black" : "border-[#00091d]"} w-fit border z-50 flex flex-col items-start gap-2 h-fit p-2 rounded-xl bg-white`}
         >
           <button 
@@ -59,15 +83,33 @@
           </button>
         </menu>
       {/if}
-
+      {#if is_font_menu_open}
+      <menu
+          class={`${theme.value === "light" ? "border-black" : "border-[#00091d]"} w-fit border z-50 flex flex-col items-center gap-2 h-fit p-2 rounded-xl bg-white ml-[50px]`}
+        >
+          <button
+            onclick={() => { font_size.value = "small"; } }
+            class="flex gap-2 text-start w-full h-full rounded-xl pl-2 pr-5 py-2 hover:bg-slate-500/10 transition-all duration-150 items-center">Small</button>
+          <button
+            onclick={() => { font_size.value = "medium"; } }
+            class="flex gap-2 text-start w-full h-full rounded-xl pl-2 pr-5 py-2 hover:bg-slate-500/10 transition-all duration-150 items-center">Medium</button>
+          <button
+            onclick={() => { font_size.value = "large"; } }
+            class="flex gap-2 text-start w-full h-full rounded-xl pl-2 pr-5 py-2 hover:bg-slate-500/10 transition-all duration-150 items-center">Large</button>
+      </menu>
+      {/if}
       <nav class={`${theme.value === "light" ? "border-black" : "border-[#00091d]"} border z-50 flex self-center items-center gap-4 mx-auto w-fit h-fit p-2 rounded-xl bg-white`}>
         <button 
-          onclick={() => is_menu_open = !is_menu_open} 
+          onclick={() => toggleMenus('main')}
           class="w-full h-fit hover:bg-slate-500/10 rounded-full"
         >
           <img src="/menu-line.svg" alt="Menu" class="w-12 h-12" />
         </button>
-
+        <button 
+          onclick={() => toggleMenus('font')}
+          class="w-full h-fit hover:bg-slate-500/10 rounded-full">
+          <img src="/menu-line.svg" alt="Font" class="w-12 h-12"/>
+        </button>
         <!-- TODO: change to <a href='/explore'> -->
         <button 
           onclick={comingSoon}

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -159,7 +159,7 @@
         </li>
       {/each}
       <li class="flex gap-4 w-full">
-        <button onclick={addTask} class="px-5 rounded-full bg-white text-black">
+        <button onclick={addTask} class="px-5 rounded-full border border-black bg-white text-black">
           +
         </button>
         <input type="text" bind:value={task_input} class="bg-transparent pr-4 py-2 border-b w-full"/>

--- a/src/routes/[id]/+page.svelte
+++ b/src/routes/[id]/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onMount } from "svelte";
   import { page } from "$app/stores";
   import { local_lists, pinned_list, generateId, type List } from "$lib/stores.svelte";
-  import { goto, pushState } from "$app/navigation";
-  import toast, { Toaster } from "svelte-french-toast";
-
+  import { goto } from "$app/navigation";
+  import toast from "svelte-french-toast";
   let is_menu_open = $state(false);
   let list : List | undefined = $state(); 
   let task_input = $state("");


### PR DESCRIPTION
Closes #14
- Implemented font menu and button according to #14
- Removed unused import in `+page.svelte` (tick, pushState, Toaster)

Notes:
- I've removed `transition:fade={{ duration: 150 }}` the two menus clashed in positioning when the fade was there it led to the menus changing position drastically for a second when the other menu is opened
- The font size only changes for `+layout.svelte` the `+page.svelte` elements each seems to have their own font size and corresponding font size for larger screens (should i make changes to the `+page.svelte` as well?)
- I've made the font menu lineup as close as possible with the font button using `ml-[75px]` im not sure how i can every menu lineup with its button ill look into it
- I put `/menu-line.svg` as a placeholder for the font button cuz i have no idea where i can get those exact style of icons